### PR TITLE
Discarding the master-slave vocabulary

### DIFF
--- a/home/migrations/0001_initial.py
+++ b/home/migrations/0001_initial.py
@@ -62,7 +62,7 @@ class Migration(migrations.Migration):
             name='ImagesModel',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('img_type', models.CharField(choices=[('default', '主图'), ('slave', '从图')], default='slave', max_length=50)),
+                ('img_type', models.CharField(choices=[('default', '主图'), ('subordinate', '从图')], default='subordinate', max_length=50)),
                 ('img_path', models.ImageField(blank=True, null=True, upload_to='', verbose_name='图片路径')),
                 ('img_url', models.URLField(blank=True, null=True, verbose_name='图片跳转url')),
                 ('product', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='home.ProductModel', verbose_name='关联外键')),

--- a/home/models.py
+++ b/home/models.py
@@ -96,7 +96,7 @@ class ProductModel(models.Model):
 
 class ImagesModel(models.Model):
     product = models.ForeignKey('ProductModel', on_delete=models.CASCADE, null=True, blank=True, verbose_name='关联外键')
-    img_type = models.CharField(choices=[('default', '主图'), ('slave', '从图')], default='slave', max_length=50)
+    img_type = models.CharField(choices=[('default', '主图'), ('subordinate', '从图')], default='subordinate', max_length=50)
     img_path = models.ImageField(verbose_name='图片路径', null=True, blank=True)
     img_url = models.URLField(verbose_name='图片跳转url', null=True, blank=True)
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.